### PR TITLE
fix: shortcut load failed due to missing origin_key

### DIFF
--- a/src/arclet/alconna/typing.py
+++ b/src/arclet/alconna/typing.py
@@ -108,6 +108,7 @@ class InnerShortcutArgs:
 
     def dump(self):
         return {
+            "origin_key": self.origin_key,
             "command": self.command,
             "args": self.args,
             "fuzzy": self.fuzzy,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Resolve an issue where shortcut loading failed due to a missing origin_key in the dump method